### PR TITLE
Support pages larger than 10MB

### DIFF
--- a/ocr/__init__.py
+++ b/ocr/__init__.py
@@ -84,8 +84,8 @@ def process_pdf(
             # re-using the same page object, as the latter can lead to strange behaviour (xref=0 and outdated values
             # from the second page.get_image_info() call). This is because the result of the page.get_image_info()
             # call is cached on the Page object, and this cache is not autmoatically cleared when modifying some of the
-            # images (e.g. calling page.replace_image()). See e.g.
-            # https://github.com/pymupdf/PyMuPDF/blob/0a9c2e85c70da1991c6336fe9760bf844d06a7af/src/utils.py#L829
+            # images (e.g. calling page.replace_image()). This has been reported as a bug on the PyMuPDF GitHub repo:
+            # https://github.com/pymupdf/PyMuPDF/issues/4303
             resize_page(in_doc, out_doc, page_index)
             replace_jpx_images(out_doc, page_index)
             crop_images(out_doc, page_index)

--- a/ocr/crop.py
+++ b/ocr/crop.py
@@ -97,7 +97,6 @@ def crop_images(page: pymupdf.Page, out_doc: pymupdf.Document):
             print("  Encountered ValueError, skipping image crop.")
 
 
-
 def replace_jpx_images(page: pymupdf.Page, out_doc: pymupdf.Document):
     images_info = {dict["xref"]: dict for dict in page.get_image_info(xrefs=True)}
     for xref, dict in images_info.items():
@@ -114,6 +113,23 @@ def replace_jpx_images(page: pymupdf.Page, out_doc: pymupdf.Document):
                     page.replace_image(xref, stream=img.tobytes('jpg', jpg_quality=85))
         except ValueError:
             print(f"  Encountered ValueError for xref {xref}, skipping replace_jpx_images.")
+
+
+def downscale_images_x2(page: pymupdf.Page, doc: pymupdf.Document):
+    images_info = {dict["xref"]: dict for dict in page.get_image_info(xrefs=True)}
+    for xref, dict in images_info.items():
+        try:
+            extracted_img = doc.extract_image(xref)
+            ext = extracted_img['ext']
+            image_bbox = pymupdf.Rect(*dict["bbox"])
+            print(f"  Downscaling {ext} image (width {dict['width']}, height {dict['height']}, bbox {image_bbox}, page.rect {page.rect}).")
+
+            img = _pixmap_from_xref(doc, xref)
+            img.shrink(1)  # reduce width and height by a factor of 2^1 = 2
+            if img:
+                page.replace_image(xref, stream=img.tobytes(ext, jpg_quality=85))
+        except ValueError:
+            print(f"  Encountered ValueError for xref {xref}, skipping downscale_images_x2.")
 
 
 def _pixmap_from_xref(doc: pymupdf.Document, xref: int) -> pymupdf.Pixmap:

--- a/ocr/crop.py
+++ b/ocr/crop.py
@@ -99,7 +99,6 @@ def crop_images(out_doc: pymupdf.Document, page_index: int):
             print("  Encountered ValueError, skipping image crop.")
 
 
-
 def replace_jpx_images(doc: pymupdf.Document, page_index: int):
     page = doc[page_index]
     for dict in page.get_image_info(xrefs=True):
@@ -119,9 +118,10 @@ def replace_jpx_images(doc: pymupdf.Document, page_index: int):
             print(f"  Encountered ValueError for xref {xref}, skipping replace_jpx_images.")
 
 
-def downscale_images_x2(page: pymupdf.Page, doc: pymupdf.Document):
-    images_info = {dict["xref"]: dict for dict in page.get_image_info(xrefs=True)}
-    for xref, dict in images_info.items():
+def downscale_images_x2(doc: pymupdf.Document, page_index: int):
+    page = doc[page_index]
+    for dict in page.get_image_info(xrefs=True):
+        xref = dict['xref']
         try:
             extracted_img = doc.extract_image(xref)
             ext = extracted_img['ext']

--- a/ocr/util.py
+++ b/ocr/util.py
@@ -38,7 +38,7 @@ def process_page(
         print(f"  Page size is {page_size / 1024 / 1024:.2f} MB, trying to downscale images.")
         # We only reduce the image resolution in the temporary PDF file that is used for AWS Textact, not in the
         # original PDF file.
-        downscale_images_x2(textract_doc[0], textract_doc)
+        downscale_images_x2(textract_doc, page_index=0)
         textract_doc.save(textract_doc_path, deflate=True, garbage=3, use_objstms=1)
 
     if os.path.getsize(textract_doc_path) < ten_mb:

--- a/ocr/util.py
+++ b/ocr/util.py
@@ -6,6 +6,7 @@ from reportlab.pdfgen import canvas
 from reportlab.pdfgen.textobject import PDFTextObject
 
 from ocr.applyocr import OCR
+from ocr.crop import downscale_images_x2
 from ocr.readingorder import TextLine, TextWord
 
 
@@ -26,19 +27,35 @@ def process_page(
     textract_doc = pymupdf.Document()
     textract_doc.insert_pdf(doc, from_page=page.number, to_page=page.number)
     textract_doc_path = OCR.tmp_file_path(tmp_path_prefix, "pdf")
-    textract_doc.save(textract_doc_path)
 
-    page_ocr = OCR(
-        textractor=extractor,
-        confidence_threshold=confidence_threshold,
-        textract_doc_path=textract_doc_path,
-        ignore_rects=ignore_rects,
-        tmp_path_prefix=tmp_path_prefix
-    )
-    lines_to_draw = page_ocr.apply_ocr(clip_rect=page.rect)
-    os.remove(textract_doc_path)
-    print("  {} new lines found".format(len(lines_to_draw)))
-    return lines_to_draw
+    ten_mb = 10 * 1024 * 1024  # 10 MB
+    textract_doc.save(textract_doc_path, deflate=True, garbage=3, use_objstms=1)
+
+    for iteration in range(10):
+        page_size = os.path.getsize(textract_doc_path)
+        if page_size < ten_mb:
+            break
+        print(f"  Page size is {page_size / 1024 / 1024:.2f} MB, trying to downscale images.")
+        # We only reduce the image resolution in the temporary PDF file that is used for AWS Textact, not in the
+        # original PDF file.
+        downscale_images_x2(textract_doc[0], textract_doc)
+        textract_doc.save(textract_doc_path, deflate=True, garbage=3, use_objstms=1)
+
+    if os.path.getsize(textract_doc_path) < ten_mb:
+        page_ocr = OCR(
+            textractor=extractor,
+            confidence_threshold=confidence_threshold,
+            textract_doc_path=textract_doc_path,
+            ignore_rects=ignore_rects,
+            tmp_path_prefix=tmp_path_prefix
+        )
+        lines_to_draw = page_ocr.apply_ocr(clip_rect=page.rect)
+        os.remove(textract_doc_path)
+        print("  {} new lines found".format(len(lines_to_draw)))
+        return lines_to_draw
+    else:
+        print("  Could not reduce page size to below 10MB. Skipping page.")
+        return []
 
 
 def draw_ocr_word(


### PR DESCRIPTION
Support pages larger than 10MB (AWS Textract limit) by progressively shrinking images on the page until the page size falls below 10MB.