### PR TITLE
introduce new debug mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,14 +73,15 @@ def main():
 
         print()
         print(asset_item.filename)
-        ocr.process(
+        ocr.Processor(
             asset_item.local_path,
+            settings.input_debug_page,
             out_path,
             asset_item.tmp_path,
             extractor.textract_client,
             settings.confidence_threshold,
             settings.use_aggressive_strategy,
-        )
+        ).process()
 
         target.save(asset_item)
 

--- a/ocr/__init__.py
+++ b/ocr/__init__.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import subprocess
 
@@ -11,72 +12,89 @@ from ocr.crop import crop_images, replace_jpx_images
 from ocr.resize import resize_page
 from ocr.util import process_page, clean_old_ocr, is_digitally_born, draw_ocr_text_page, clean_old_ocr_aggressive
 
+@dataclasses.dataclass
+class Processor:
+    input_path: Path
+    debug_page: int | None
+    output_path: Path
+    tmp_dir: Path
+    textractor: Textractor
+    confidence_threshold: float
+    use_aggressive_strategy: bool
 
-def process(
-        input_path: Path,
-        output_path: Path,
-        tmp_dir: Path,
-        textractor: Textractor,
-        confidence_threshold: float,
-        use_aggressive_strategy: bool,
-):
-    try:
-        process_pdf(
-            input_path,
-            output_path,
-            tmp_dir,
-            textractor,
-            confidence_threshold,
-            use_aggressive_strategy
-        )
-    except (ValueError, mupdf.FzErrorArgument, mupdf.FzErrorFormat) as e:
-        gs_preprocess_path = tmp_dir / "gs.pdf"
-        print(f"Encountered {e.__class__.__name__}: {e}. Trying Ghostscript preprocessing.")
-        subprocess.call([
-            "gs",
-            "-sDEVICE=pdfwrite",
-            "-dCompatibilityLevel=1.4",
-            "-dPDFSETTINGS=/default",
-            "-dNOPAUSE",
-            "-dQUIET",
-            "-dBATCH",
-            "-sOutputFile={}".format(gs_preprocess_path),
-            input_path,
-        ])
-        process_pdf(
-            gs_preprocess_path,
-            output_path,
-            tmp_dir,
-            textractor,
-            confidence_threshold,
-            use_aggressive_strategy,
-        )
+    def process(self):
+        try:
+            self.process_pdf(self.input_path)
+        except (ValueError, mupdf.FzErrorArgument, mupdf.FzErrorFormat) as e:
+            gs_preprocess_path = self.tmp_dir / "gs.pdf"
+            print(f"Encountered {e.__class__.__name__}: {e}. Trying Ghostscript preprocessing.")
+            subprocess.call([
+                "gs",
+                "-sDEVICE=pdfwrite",
+                "-dCompatibilityLevel=1.4",
+                "-dPDFSETTINGS=/default",
+                "-dNOPAUSE",
+                "-dQUIET",
+                "-dBATCH",
+                "-sOutputFile={}".format(gs_preprocess_path),
+                self.input_path,
+            ])
+            self.process_pdf(gs_preprocess_path)
 
+    def process_pdf(self, in_path: Path):
+        tmp_out_path = os.path.join(self.tmp_dir, f"output.incremental.pdf")
 
-def process_pdf(
-        in_path: Path,
-        out_path: Path,
-        tmp_dir: Path,
-        textractor: Textractor,
-        confidence_threshold: float,
-        use_aggressive_strategy: bool,
-):
-    tmp_out_path = os.path.join(tmp_dir, f"output.incremental.pdf")
+        in_doc = pymupdf.open(in_path)
+        out_doc = pymupdf.open(in_path)
 
-    in_doc = pymupdf.open(in_path)
-    out_doc = pymupdf.open(in_path)
+        os.makedirs(self.tmp_dir, exist_ok=True)
 
-    os.makedirs(tmp_dir, exist_ok=True)
+        in_page_count = in_doc.page_count
 
-    in_page_count = in_doc.page_count
+        out_doc.save(tmp_out_path, garbage=3, deflate=True)
+        out_doc.close()
+        out_doc = pymupdf.open(tmp_out_path)
 
-    out_doc.save(tmp_out_path, garbage=3, deflate=True)
-    out_doc.close()
-    out_doc = pymupdf.open(tmp_out_path)
-    for page_index, new_page in enumerate(iter(in_doc)):
+        for page_index, new_page in enumerate(iter(in_doc)):
+            page_number = page_index + 1
+            if not self.debug_page or page_number == self.debug_page:
+                print(f"{os.path.basename(in_path)}, page {page_number}/{in_page_count}")
+                self.process_page(in_doc, page_index, out_doc, tmp_out_path, add_debug_page=bool(self.debug_page))
+                out_doc.saveIncr()
+
+        if self.debug_page:
+            # only keep the debug page in its two versions (original + text-only)
+            out_doc.delete_pages(range(0, self.debug_page - 1))
+            out_doc.delete_pages(range(2, out_doc.page_count))
+            out_doc.saveIncr()
+
+        out_doc.close()
+        in_doc.close()
+        out_doc = pymupdf.open(tmp_out_path)
+        out_doc.save(self.output_path, garbage=3, deflate=True, use_objstms=1)
+        out_doc.close()
+
+        # Verify that we can read the written document, and that it still has the same number of pages. Some corrupt input
+        # documents might lead to an empty or to a corrupt output document, sometimes even without throwing an error. (See
+        # LGD-283.) This check should detect such cases.
+        doc = pymupdf.open(self.output_path)
+        if not self.debug_page:
+            out_page_count = doc.page_count
+            if in_page_count != out_page_count:
+                raise ValueError(
+                    "Output document contains {} pages instead of {}".format(out_page_count, in_page_count)
+                )
+        doc.close()
+
+    def process_page(
+        self,
+        in_doc: pymupdf.Document,
+        page_index: int,
+        out_doc: pymupdf.Document,
+        tmp_out_path: str,
+        add_debug_page: bool = False
+    ):
         page_number = page_index + 1
-        print(f"{os.path.basename(in_path)}, page {page_number}/{in_page_count}")
-
         digitally_born = is_digitally_born(in_doc[page_index])
 
         if not digitally_born:
@@ -92,7 +110,7 @@ def process_pdf(
 
         new_page = out_doc[page_index]
 
-        if use_aggressive_strategy:
+        if self.use_aggressive_strategy:
             ignore_rects = clean_old_ocr_aggressive(new_page)
         else:
             if not digitally_born:
@@ -100,26 +118,13 @@ def process_pdf(
                 ignore_rects = []
             else:
                 print(" Skipping digitally-born page.")
-                continue
-        tmp_path_prefix = os.path.join(tmp_dir, f"page{page_number}")
-        text_layer_path = os.path.join(tmp_dir, f"page{page_number}.pdf")
-        lines_to_draw = process_page(out_doc, new_page, textractor, tmp_path_prefix, confidence_threshold, ignore_rects)
+                return
+        tmp_path_prefix = os.path.join(self.tmp_dir, f"page{page_number}")
+        lines_to_draw = process_page(out_doc, new_page, self.textractor, tmp_path_prefix, self.confidence_threshold, ignore_rects)
+
+        text_layer_path = os.path.join(self.tmp_dir, f"page{page_number}.pdf")
         draw_ocr_text_page(new_page, text_layer_path, lines_to_draw)
-        out_doc.save(tmp_out_path, incremental=True, encryption=PDF_ENCRYPT_KEEP)
+        if add_debug_page:
+            debug_page = out_doc.new_page(new_page.number + 1, new_page.rect.width, new_page.rect.height)
+            draw_ocr_text_page(debug_page, text_layer_path, lines_to_draw, visible=True)
 
-    out_doc.close()
-    in_doc.close()
-    out_doc = pymupdf.open(tmp_out_path)
-    out_doc.save(out_path, garbage=3, deflate=True, use_objstms=1)
-    out_doc.close()
-
-    # Verify that we can read the written document, and that it still has the same number of pages. Some corrupt input
-    # documents might lead to an empty or to a corrupt output document, sometimes even without throwing an error. (See
-    # LGD-283.) This check should detect such cases.
-    doc = pymupdf.open(out_path)
-    out_page_count = doc.page_count
-    if in_page_count != out_page_count:
-        raise ValueError(
-            "Output document contains {} pages instead of {}".format(out_page_count, in_page_count)
-        )
-    doc.close()

--- a/ocr/util.py
+++ b/ocr/util.py
@@ -102,7 +102,8 @@ def draw_ocr_word(
 def draw_ocr_text_page(
         page: pymupdf.Page,
         text_layer_path: str,
-        lines: list[TextLine]
+        lines: list[TextLine],
+        visible: bool=False
 ):
     """
     Draw hidden OCR text on the page.
@@ -123,7 +124,8 @@ def draw_ocr_text_page(
     c.saveState()
     current_orientation = 0
     text = c.beginText(0, 0)
-    text.setTextRenderMode(3)
+    if not visible:
+        text.setTextRenderMode(3)
 
     for line in lines:
         if line.orientation != current_orientation:

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -35,6 +35,7 @@ class ScriptSettings(SharedSettings):
     input_s3_bucket: str | None = None
     input_s3_prefix: str | None = None
     input_skip_existing: bool
+    input_debug_page: int | None
 
     output_type: Literal['path', 's3']
     output_path: str | None = None


### PR DESCRIPTION
- When setting the environment variable `INPUT_DEBUG_PAGE` to a particular page number, the pipeline will only process that page, and additional create a version of the page with only the OCR layer (with visible text).
- Create a new class Processor that groups some related methods, which were previously stand-alone methods.

closes #17 