### PR TITLE
fix process call in API

### DIFF
--- a/api.py
+++ b/api.py
@@ -115,14 +115,15 @@ def process(
         str(input_path),
     )
 
-    ocr.process(
-        input_path,
-        output_path,
-        tmp_dir,
-        aws_client.textract,
-        settings.confidence_threshold,
-        settings.use_aggressive_strategy,
-    )
+    ocr.Processor(
+        input_path=input_path,
+        debug_page=None,
+        output_path=output_path,
+        tmp_dir=tmp_dir,
+        textractor=aws_client.textract,
+        confidence_threshold=settings.confidence_threshold,
+        use_aggressive_strategy=settings.use_aggressive_strategy,
+    ).process()
 
     aws.store_file(
         aws_client.bucket(settings.s3_output_bucket),


### PR DESCRIPTION
@daniel-va I believe that this should fix the problem from https://github.com/swisstopo/swissgeol-assets-suite/issues/392#issuecomment-2713849762

I was not yet able to test the API locally, since I first need to upgrade Python on my machine (I was still using 3.10, but the API seems to require 3.12).

What we really need is some CI GitHub action that does a test run of the API endpoints for every PR... For that however we first need to have a possibility to mock both S3 (@flenny is already looking into something like this here: https://github.com/swisstopo/swissgeol-boreholes-suite/issues/1891#issuecomment-2713097689) as well as Textract.