### PR TITLE
Assets-456: Add page number to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Additional features:
   multiple requests. Indeed, AWS Textract has
   certain [limits on file size and page dimensions](https://docs.aws.amazon.com/textract/latest/dg/limits-document.html),
   and even within those limits, the quality of the results is better when the input dimensions are smaller.
+- Adds metadata to the object after processing, currently containing:
+  - `X-Amz-Meta-Pagecount`: The number of pages in the document if available, else the key is not set
 
 ## Installation
 
@@ -143,6 +145,7 @@ AWS_PROFILE=swisstopo-ngm
 
 # During local development, an S3-compatible service like MinIO (https://min.io/) can be used.
 # In this case, the endpoint will look like `http://minio:9000`.
+# Note that if MinIO is used, you still need to configure AWS_DEFAULT_REGION if none is set in your AWS credentials.
 S3_INPUT_ENDPOINT=https://s3.eu-central-1.amazonaws.com
 S3_INPUT_BUCKET=swissgeol-assets-swisstopo
 S3_INPUT_FOLDER=asset_files/

--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ def main():
 
         print()
         print(asset_item.filename)
-        ocr.Processor(
+        process_result = ocr.Processor(
             asset_item.local_path,
             settings.input_debug_page,
             out_path,
@@ -83,7 +83,7 @@ def main():
             settings.use_aggressive_strategy,
         ).process()
 
-        target.save(asset_item)
+        target.save(asset_item, process_result)
 
         if settings.cleanup_tmp_files:
             shutil.rmtree(asset_item.tmp_path)


### PR DESCRIPTION
See swisstopo/swissgeol-assets-suite#456
* Adds the page count of a processed PDF to the object's metadata (`X-Amz-Meta-Page-Count`) which is taken from the current processing.
* Adds an extended debug mode that generates a random page number (or None) for a processed file during local development
  * It would be cleaner to _actually_ return the page number from the process, since that can be started even if you want to skip text extraction. That would require more significant changes to the processing however (i.e. the skip would have to happen in the process), which I wasn't sure if we should do that, given that you mentioned other areas you'd like to focus on